### PR TITLE
Remove pokemongo-webspoof as it is not safe anymore

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -50,7 +50,6 @@ Please check the <a href="https://github.com/tobiasbueschel/awesome-pokemon/blob
 
 #### Apps
 - [Pokemon-Showdown](https://github.com/Zarel/Pokemon-Showdown) - Pokémon battle simulator.
-- [pokemongo-webspoof](https://github.com/iam4x/pokemongo-webspoof) - Play Pokémon GO from your Mac.
 - [iPokeMon](https://github.com/Kjuly/iPokeMon) - Pokémon like game on iOS with Location Based Service.
 - [pokemon-online](https://github.com/po-devs/pokemon-online) - Online Pokémon Battle Simulator.
 - [Shuffle-Move](https://github.com/Loreinator/Shuffle-Move) - A program to identify and display the best next move for the game Pokémon Shuffle.


### PR DESCRIPTION
Removed pokemongo-webspoof as it is no longer safe to use, as per their documentation and a related issue.

https://github.com/iam4x/pokemongo-webspoof