### PR TITLE
Add TCG Price Lookup to APIs section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -49,6 +49,7 @@ Please check the <a href="https://github.com/tobiasbueschel/awesome-pokemon/blob
 - [PokemonGO-Pokedex](https://github.com/Biuni/PokemonGO-Pokedex) - Pokédex of Pokémon GO in JSON.
 - [PokeTypes](https://github.com/fbosch/poke-types) - Get Pokémon types, weaknesses and strengths.
 - [TCGdex](https://github.com/tcgdex/cards-database) - Multi languages Pokémon TCG API.
+- [TCG Price Lookup](https://tcgpricelookup.com/tcg-api) - Live trading card prices for Pokémon and 7 other TCGs with TCGPlayer market data, eBay sold averages, and PSA/BGS/CGC graded prices.
 - [Kotlin-Pokedex](https://github.com/mrcsxsiq/Kotlin-Pokedex) - Pokedex app built with Kotlin.
 - [graphql-pokemon](https://github.com/lucasbento/graphql-pokemon) - Get information of a Pokémon with GraphQL.
 


### PR DESCRIPTION
Adds **[TCG Price Lookup](https://tcgpricelookup.com/tcg-api)** — a REST API for live trading card prices that covers Pokémon alongside 7 other TCGs (MTG, Yu-Gi-Oh!, Lorcana, One Piece, Star Wars Unlimited, Flesh and Blood).

Unlike the Pokémon-only APIs already listed, TCG Price Lookup also returns **actual pricing data** — TCGPlayer market prices, eBay sold averages, and PSA/BGS/CGC graded comps.

- Free tier: 10,000 req/month
- Official SDKs: [JS](https://github.com/TCG-Price-Lookup/tcglookup-js), [Python](https://github.com/TCG-Price-Lookup/tcglookup-py), [Go](https://github.com/TCG-Price-Lookup/tcglookup-go), [Rust](https://github.com/TCG-Price-Lookup/tcglookup-rs), [PHP](https://github.com/TCG-Price-Lookup/tcglookup-php)
- [GitHub org](https://github.com/TCG-Price-Lookup)