### PR TITLE
Add Monteams team builder

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -55,6 +55,7 @@ Please check the <a href="https://github.com/tobiasbueschel/awesome-pokemon/blob
 #### Apps
 - [Pokemon-Showdown](https://github.com/Zarel/Pokemon-Showdown) - Pokémon battle simulator.
 - [iPokeMon](https://github.com/Kjuly/iPokeMon) - Pokémon like game on iOS with Location Based Service.
+- [Monteams](https://monteams.com/) - Browser-based Pokémon team builder with generation-specific Pokédexes and type coverage analysis.
 - [pokemon-online](https://github.com/po-devs/pokemon-online) - Online Pokémon Battle Simulator.
 - [Shuffle-Move](https://github.com/Loreinator/Shuffle-Move) - A program to identify and display the best next move for the game Pokémon Shuffle.
 - [pokecry](https://github.com/fent/pokecry) - Guess Pokémon from their cry.


### PR DESCRIPTION
## Summary
- Add Monteams, a free browser-based Pokemon team builder, to the Apps section.
- It supports generation-specific Pokedexes and type coverage analysis for team planning.

Live site: https://monteams.com/

This is an individual suggestion, formatted and alphabetized according to the contribution guidelines.